### PR TITLE
Don't write file if keys haven't changed

### DIFF
--- a/sync_ssh_users.py
+++ b/sync_ssh_users.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from hashlib import md5
 import json
 import logging
 import os
@@ -91,8 +92,20 @@ def add_ssh_keys(user):
 
     key_file = os.path.join(ssh_directory, 'authorized_keys')
 
-    _ensure_directory(ssh_directory)
-    _write_ssh_file(key_file, key_file_content, username)
+    if _file_has_changed(key_file, key_file_content):
+        _ensure_directory(ssh_directory)
+        _write_ssh_file(key_file, key_file_content, username)
+
+
+def _file_has_changed(key_file, key_file_content):
+    if not os.path.exists(key_file):
+        return True
+    key_data = key_file_content.encode('utf-8')
+    with open(key_file, 'rb') as f:
+        existing_key_data = f.read()
+    if existing_key_data != key_data:
+        return True
+    return md5(key_data).hexdigest() != md5(existing_key_data).hexdigest()
 
 
 def _write_ssh_file(path: str, content: str, username: str):

--- a/sync_ssh_users.py
+++ b/sync_ssh_users.py
@@ -97,15 +97,15 @@ def add_ssh_keys(user):
         _write_ssh_file(key_file, key_file_content, username)
 
 
-def _file_has_changed(key_file, key_file_content):
-    if not os.path.exists(key_file):
+def _file_has_changed(file, file_content):
+    if not os.path.exists(file):
         return True
-    key_data = key_file_content.encode('utf-8')
-    with open(key_file, 'rb') as f:
-        existing_key_data = f.read()
-    if existing_key_data != key_data:
+    data = file_content.encode('utf-8')
+    with open(file, 'rb') as f:
+        existing_data = f.read()
+    if existing_data != data:
         return True
-    return md5(key_data).hexdigest() != md5(existing_key_data).hexdigest()
+    return md5(data).hexdigest() != md5(existing_data).hexdigest()
 
 
 def _write_ssh_file(path: str, content: str, username: str):

--- a/test_sync_ssh_users.py
+++ b/test_sync_ssh_users.py
@@ -119,3 +119,21 @@ class TestSync(unittest.TestCase):
         # Then
         with open('/home/ddg/.ssh/authorized_keys') as f:
             assert len(f.read()) == 0
+
+    def test_does_not_write_keys_if_no_change(self):
+        # Given
+        user = sync_ssh_users.User('aad', ['ssh-rsa foo'])
+        sync_ssh_users.add_user(user.login)
+        sync_ssh_users.add_ssh_keys(user)
+
+        modified_time = os.stat(f'/home/{user.login}/.ssh/authorized_keys')\
+            .st_mtime
+
+        # When
+        sync_ssh_users.main()
+
+        # Then
+        latest_modified_time = os.stat(
+            f'/home/{user.login}/.ssh/authorized_keys'
+        ).st_mtime
+        assert latest_modified_time == modified_time


### PR DESCRIPTION
There's no need to keep writing the same content to disk every minute.